### PR TITLE
portmap is no longer used in ubuntu 13.10

### DIFF
--- a/manifests/debian/services.pp
+++ b/manifests/debian/services.pp
@@ -4,11 +4,18 @@ class portmap::debian::services (
 ) {
 
     # FIXME I assume I'll need to do something with idmapd
-    $services = 'portmap'
+
+    case $::lsbdistrelease {
+      13.10 : {
+        $services = 'rpcbind'
+      }
+      default : {
+        $services = 'portmap'
+      }
+    }
 
     service { $services:
         ensure => $ensure,
         enable => $enable,
     }
-
 }


### PR DESCRIPTION
rpcbind is the name of the service in ubuntu 13.10.  This adds a fix for 13.10.
