### PR TITLE
Added Debian 7 support.

### DIFF
--- a/manifests/debian/services.pp
+++ b/manifests/debian/services.pp
@@ -5,12 +5,26 @@ class portmap::debian::services (
 
     # FIXME I assume I'll need to do something with idmapd
 
-    case $::lsbdistrelease {
-      13.10 : {
-        $services = 'rpcbind'
+    case $::lsbdistid  {
+      /(ubuntu|Ubuntu)/ : {
+        case $::lsbdistrelease {
+          13.10 : {
+            $services = 'rpcbind'
+          }
+          default : {
+            $services = 'portmap'
+          }
+        }
       }
-      default : {
-        $services = 'portmap'
+      /(debian|Debian)/ : {
+        case $::lsbmajdistrelease {
+          7 : {
+            $services = 'rpcbind'
+          }
+          default : {
+            $services = 'portmap'
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Debian 7 also uses the rpcbind init script instead of portmap. I therefore made the following change to unsure that the proper service was specified. 

Please note that I tested this on a amd64 Debian 7.x system and a Raspbian 7.x system running on a raspberry pi.
