### PR TITLE
Adding Amazon Linux support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,15 +45,15 @@ class portmap (
 
     anchor { 'portmap::begin': }
 
-    case $::operatingsystem {
-        centos, redhat : {
+    case $::osfamily {
+        RedHat : {
             class { 'portmap::rhel':
                 package => $package,
                 service => $service,
                 enable  => $enable,
             }
         }
-        debian, ubuntu : {
+        Debian : {
             class { 'portmap::debian':
                 package => $package,
                 service => $service,

--- a/manifests/rhel/packages.pp
+++ b/manifests/rhel/packages.pp
@@ -2,9 +2,12 @@ class portmap::rhel::packages (
     $ensure = installed,
 ) {
 
-    $packages = $::operatingsystemmajrelease ? {
-        5 => 'portmap',
-        6 => 'rpcbind',
+    $packages = $::operatingsystem ? {
+        "Amazon" => 'rpcbind',
+        default  => $::operatingsystemmajrelease ? {
+            5 => 'portmap',
+            6 => 'rpcbind',
+      }
     }
 
     package { $packages:

--- a/manifests/rhel/services.pp
+++ b/manifests/rhel/services.pp
@@ -3,9 +3,12 @@ class portmap::rhel::services (
     $enable = true,
 ) {
 
-    $services = $::operatingsystemmajrelease ? {
-        5 => 'portmap',
-        6 => 'rpcbind',
+    $services = $::operatingsystem ? {
+        'Amazon' => 'rpcbind',
+        default  => $::operatingsystemmajrelease ? {
+            5 => 'portmap',
+            6 => 'rpcbind',
+        }
     }
 
     service { $services:


### PR DESCRIPTION
Switching from operatingsystem to osfamily fact for Amazon Linux
support, compatible with RHEL/CentOS but not tested on Fedora.
