### PR TITLE
OpenBSD support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,12 @@ class portmap (
                 enable  => $enable,
             }
         }
+        OpenBSD : {
+            class { 'portmap::openbsd':
+                service => $service,
+                enable  => $enable,
+            }
+        }
         default : {
             fail("portmap is not currently supported on ${::operatingsystem}")
         }

--- a/manifests/openbsd.pp
+++ b/manifests/openbsd.pp
@@ -1,0 +1,18 @@
+# portmap::openbsd takes care about OpenBSD
+# specific parameters.
+
+class portmap::openbsd (
+    $service = running,
+    $enable  = true,
+) {
+
+    anchor { 'portmap::openbsd::begin': }
+
+    class { 'portmap::openbsd::services':
+        ensure => $service,
+        enable => $enable,
+    }
+
+    anchor { 'portmap::openbsd::end': }
+
+}

--- a/manifests/openbsd/services.pp
+++ b/manifests/openbsd/services.pp
@@ -1,0 +1,15 @@
+# class portmap::openbsd::services takes
+# care about the state of the service on
+# OpenBSD OS.
+
+class portmap::openbsd::services (
+    $ensure = running,
+    $enable = true,
+) {
+
+    service { 'portmap':
+        ensure => $ensure,
+        enable => $enable,
+    }
+
+}


### PR DESCRIPTION
This patch below adds support to manage OpenBSD portmap.
It doesn't need to install a package, since its part of OpenBSD base distribution.
