### PR TITLE
Not matching on osfamily case statement

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,21 +46,21 @@ class portmap (
     anchor { 'portmap::begin': }
 
     case $::osfamily {
-        RedHat : {
+        'RedHat': {
             class { 'portmap::rhel':
                 package => $package,
                 service => $service,
                 enable  => $enable,
             }
         }
-        Debian : {
+        'Debian': {
             class { 'portmap::debian':
                 package => $package,
                 service => $service,
                 enable  => $enable,
             }
         }
-        OpenBSD : {
+        'OpenBSD': {
             class { 'portmap::openbsd':
                 service => $service,
                 enable  => $enable,


### PR DESCRIPTION
Same issue with this module that I was having with the nfs module

```
[ root@ ~]# puppet apply testing.pp 
Warning: Config file /etc/puppet/hiera.yaml not found, using Hiera defaults
Error: portmap is not currently supported on CentOS on node eng-to01.lab.iot1.com
Error: portmap is not currently supported on CentOS on node eng-to01.lab.iot1.com
[ root ~]# cat testing.pp 
include nfsserver

class nfsserver {
  class { 'nfs::server':
    package => installed,
    service => running,
    enable  => true,
  }

  nfs::export { '/opt/ota':
    options => [ 'rw', 'no_root_squash', ],
    clients => [ '10.12.90.62/32', '10.12.90.61/32' ],
  }

}
```
