### PR TITLE
Using single quotes. to fix select statements

### DIFF
--- a/manifests/debian/services.pp
+++ b/manifests/debian/services.pp
@@ -8,10 +8,10 @@ class portmap::debian::services (
     case $::lsbdistid  {
       /(ubuntu|Ubuntu)/ : {
         case $::lsbdistrelease {
-          13.10 : {
+          '13.10' : {
             $services = 'rpcbind'
           }
-          14.04 : {
+          '14.04' : {
             $services = 'rpcbind'
           }
           default : {
@@ -21,7 +21,7 @@ class portmap::debian::services (
       }
       /(debian|Debian)/ : {
         case $::lsbmajdistrelease {
-          7 : {
+          '7' : {
             $services = 'rpcbind'
           }
           default : {

--- a/manifests/rhel/packages.pp
+++ b/manifests/rhel/packages.pp
@@ -5,9 +5,9 @@ class portmap::rhel::packages (
     $packages = $::operatingsystem ? {
         "Amazon" => 'rpcbind',
         default  => $::operatingsystemmajrelease ? {
-            5 => 'portmap',
-            6 => 'rpcbind',
-            7 => 'rpcbind',
+            '5' => 'portmap',
+            '6' => 'rpcbind',
+            '7' => 'rpcbind',
       }
     }
 

--- a/manifests/rhel/services.pp
+++ b/manifests/rhel/services.pp
@@ -6,9 +6,9 @@ class portmap::rhel::services (
     $services = $::operatingsystem ? {
         'Amazon' => 'rpcbind',
         default  => $::operatingsystemmajrelease ? {
-            5 => 'portmap',
-            6 => 'rpcbind',
-            7 => 'rpcbind',
+            '5' => 'portmap',
+            '6' => 'rpcbind',
+            '7' => 'rpcbind',
         }
     }
 


### PR DESCRIPTION
On Puppet 3.8 and higher, the language is more strict on strings. This PR fixes this.
