### PR TITLE
Support debian 8 (jessie)

### DIFF
--- a/manifests/debian/services.pp
+++ b/manifests/debian/services.pp
@@ -24,6 +24,9 @@ class portmap::debian::services (
           '7' : {
             $services = 'rpcbind'
           }
+          '8' : {
+            $services = 'rpcbind'
+          }
           default : {
             $services = 'portmap'
           }


### PR DESCRIPTION
Service name is still rpcbind in jessie - gets set to portmap currently.
